### PR TITLE
Feat: 리프레시 토큰 사용하여 멕세스 토큰 호출 할 때 마다 재발급

### DIFF
--- a/src/hooks/useUserStore.tsx
+++ b/src/hooks/useUserStore.tsx
@@ -1,7 +1,15 @@
 "use client";
 
+import exp from 'constants';
+import { promises } from 'dns';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import axios from 'axios'
+
+interface Tokens {
+    accessToken: string;
+    refreshToken: string;
+}
 
 interface User {
     id: number;
@@ -15,29 +23,53 @@ interface User {
 interface UserState {
     user: User | null;
     accessToken: string | null;
+    refreshToken: string | null;
     loading: boolean;
     error: string | null;
-    setUser: (user: User, accessToken: string) => void;
+    setUser: (user: User, accessToken: string, refreshToken: string) => void;
     clearUser: () => void;
     setLoading: (loading: boolean) => void;
     setError: (error: string | null) => void;
+    accessToRefresh: () => Promise<void>;
 }
 
 export const useUserStore = create<UserState>()(
     persist(
-        (set) => ({
+        (set, get) => ({
             user: null,
             accessToken: null,
+            refreshToken: null,
             loading: false,
             error: null,
-            setUser: (user: User, accessToken: string) =>
-                set({ user, accessToken, loading: false, error: null }),
-            clearUser: () => set({ user: null, accessToken: null }),
+            setUser: (user: User, accessToken: string, refreshToken: string) =>
+                set({ user, accessToken, refreshToken, loading: false, error: null }),
+            clearUser: () => set({ user: null, accessToken: null, refreshToken: null }),
             setLoading: (loading: boolean) => set({ loading }),
             setError: (error: string | null) => set({ error, loading: false }),
+            accessToRefresh: async () => {
+                const { refreshToken } = get();
+                const response = await axios.post<Tokens>(
+                    'https://sp-globalnomad-api.vercel.app/7-7/auth/tokens',
+                    {},
+                    {
+                        headers: {
+                            Authorization: `Bearer ${refreshToken}`,
+                        },
+                    }
+                );
+                const accessToken = response.data.accessToken;
+                const newRefreshToken = response.data.refreshToken;
+                set({ accessToken, refreshToken: newRefreshToken });
+            }
         }),
         {
             name: 'user-storage',
         }
     )
 );
+
+export const getAccessTokenWithRefresh = async (): Promise<string | null> => {
+    const { accessToken, accessToRefresh } = useUserStore.getState()
+    await accessToRefresh();
+    return useUserStore.getState().accessToken;
+}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -37,7 +37,7 @@ const Login = () => {
             console.log(data);
             const { user, accessToken, refreshToken } = data;
 
-            setUser(user, accessToken);
+            setUser(user, accessToken, refreshToken);
             localStorage.setItem('accessToken', accessToken);
             localStorage.setItem('refreshToken', refreshToken);
             router.push('/');

--- a/src/pages/mypage/infoPage.tsx
+++ b/src/pages/mypage/infoPage.tsx
@@ -3,7 +3,7 @@
 import axios from 'axios'
 import { IUser, IUserInforEdit } from '@/types/user'
 import { useRouter } from 'next/router'
-import { useUserStore } from '@/hooks/useUserStore'
+import { useUserStore, getAccessTokenWithRefresh } from '@/hooks/useUserStore'
 import React, { useEffect, useState } from 'react'
 import Input from '@/components/Input/Input';
 
@@ -14,12 +14,14 @@ function InfoPage() {
     const [passwordConfirm, setPasswordConfirm] = useState('')
     const [profileImageUrl, setProfileImageUrl] = useState('https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/profile_image/7-7_1119_1728047280262.jpeg')
     const router = useRouter();
-    const { user, accessToken, setUser } = useUserStore();
+    const { user, setUser } = useUserStore();
 
     useEffect(() => {
         const myInfo = async () => {
             try {
-                console.log(accessToken)
+                const accessToken = await getAccessTokenWithRefresh()
+
+                console.log(accessToken);
                 const response = await axios.get<IUser>('https://sp-globalnomad-api.vercel.app/7-7/users/me', {
                     headers: { Authorization: `Bearer ${accessToken}`, },
                 });
@@ -37,7 +39,7 @@ function InfoPage() {
 
     const edit = async () => {
         try {
-            console.log(accessToken)
+            const accessToken = await getAccessTokenWithRefresh()
             const response = await axios.patch<IUserInforEdit>(
                 'https://sp-globalnomad-api.vercel.app/7-7/users/me',
                 {


### PR DESCRIPTION
## 🔨 작업 내용
리프레시 토큰 사용하여 멕세스 토큰 호출 할 때 마다 재발급하는 것을 구현했습니다...!
엑세스 토큰을 매번 갱신해서 토큰이 소멸되지 않도록 합니다

## ✈️ 사용 방법

page -> mypage -> infopage 에 사용 예시가 있습니다!

요약하자면

맨 위에 `import { useUserStore, getAccessTokenWithRefresh } from '@/hooks/useUserStore'` 을 통해서 `getAccessTokenWithRefresh ` 함수를 import 합니다

![image](https://github.com/user-attachments/assets/1178ff22-1a3a-40a1-b1ec-dc720abdaab7)

다음에 api 호출하기 직전에 accessToken을 `getAccessTokenWithRefresh ` 함수를 통해서 꺼내 쓰면 됩니다!!